### PR TITLE
Clean up 'real_main` and fix oversight with tempfile fallbacks.

### DIFF
--- a/open_in_mpv/constants.py
+++ b/open_in_mpv/constants.py
@@ -21,7 +21,8 @@ MAC_HOSTS_DIRS: Final[tuple[str, ...]] = (
     f'{HOME}/Library/Application Support/Chromium/NativeMessagingHosts',
     f'{HOME}/Library/Application Support/Google/Chrome Beta/NativeMessagingHosts',
     f'{HOME}/Library/Application Support/Google/Chrome Canary/NativeMessagingHosts',
-    f'{HOME}/Library/Application Support/Google/Chrome/NativeMessagingHosts')
+    f'{HOME}/Library/Application Support/Google/Chrome/NativeMessagingHosts',
+    f'{HOME}/Library/Application Support/Mozilla/NativeMessagingHosts/')
 
 MACPORTS_BIN_PATH: Final[str] = '/opt/local/bin'
 
@@ -33,7 +34,8 @@ USER_HOSTS_DIRS: Final[tuple[str, ...]] = (
     f'{xdg.BaseDirectory.xdg_config_home}/chromium/NativeMessagingHosts',
     f'{xdg.BaseDirectory.xdg_config_home}/google-chrome-beta/NativeMessagingHosts',
     f'{xdg.BaseDirectory.xdg_config_home}/google-chrome-canary/NativeMessagingHosts',
-    f'{xdg.BaseDirectory.xdg_config_home}/google-chrome/NativeMessagingHosts')
+    f'{xdg.BaseDirectory.xdg_config_home}/google-chrome/NativeMessagingHosts',
+    f'{xdg.BaseDirectory.xdg_config_home}/.mozilla/native-messaging-hosts/')
 
 COMMON_HOST_DATA: Final[dict[str, str | None]] = {
     'description': 'Opens a URL in mpv (for use with extension).',

--- a/open_in_mpv/constants.py
+++ b/open_in_mpv/constants.py
@@ -17,17 +17,18 @@ HOME: Final[str] = os.environ.get('HOME', '')
 
 USER_CHROME_HOSTS_REG_PATH_WIN: Final[str] = 'HKCU:\\Software\\Google\\Chrome\\NativeMessagingHosts'
 
-MAC_HOSTS_DIRS: Final[tuple[str, str, str, str]] = (f'{HOME}/Library/Application Support/Chromium/NativeMessagingHosts',
-                  f'{HOME}/Library/Application Support/Google/Chrome Beta/NativeMessagingHosts',
-                  f'{HOME}/Library/Application Support/Google/Chrome Canary/NativeMessagingHosts',
-                  f'{HOME}/Library/Application Support/Google/Chrome/NativeMessagingHosts')
+MAC_HOSTS_DIRS: Final[tuple[str, ...]] = (
+    f'{HOME}/Library/Application Support/Chromium/NativeMessagingHosts',
+    f'{HOME}/Library/Application Support/Google/Chrome Beta/NativeMessagingHosts',
+    f'{HOME}/Library/Application Support/Google/Chrome Canary/NativeMessagingHosts',
+    f'{HOME}/Library/Application Support/Google/Chrome/NativeMessagingHosts')
 
-MAC_BIN_PATH: Final[str] = '/opt/local/bin'
+MACPORTS_BIN_PATH: Final[str] = '/opt/local/bin'
 
 SYSTEM_HOSTS_DIRS: Final[tuple[str, str, str]] = ('/etc/chromium/native-messaging-hosts',
                      '/etc/opt/chrome/native-messaging-hosts',
                      '/etc/opt/edge/native-messaging-hosts')
-USER_HOSTS_DIRS: Final[tuple[str, str, str, str, str]] = (
+USER_HOSTS_DIRS: Final[tuple[str, ...]] = (
     f'{xdg.BaseDirectory.xdg_config_home}/BraveSoftware/Brave-Browser/NativeMessagingHosts',
     f'{xdg.BaseDirectory.xdg_config_home}/chromium/NativeMessagingHosts',
     f'{xdg.BaseDirectory.xdg_config_home}/google-chrome-beta/NativeMessagingHosts',

--- a/open_in_mpv/constants.py
+++ b/open_in_mpv/constants.py
@@ -12,40 +12,40 @@ IS_MAC: Final[bool] = bool(platform.mac_ver()[0])
 IS_WIN: Final[bool] = bool(platform.win32_ver()[0])
 IS_LINUX: Final[bool] = not IS_MAC and not IS_WIN
 
-JSON_FILENAME = 'sh.tat.open_in_mpv.json'
-HOME = os.environ.get('HOME', '')
+JSON_FILENAME: Final[str] = 'sh.tat.open_in_mpv.json'
+HOME: Final[str] = os.environ.get('HOME', '')
 
-USER_CHROME_HOSTS_REG_PATH_WIN = 'HKCU:\\Software\\Google\\Chrome\\NativeMessagingHosts'
+USER_CHROME_HOSTS_REG_PATH_WIN: Final[str] = 'HKCU:\\Software\\Google\\Chrome\\NativeMessagingHosts'
 
-MAC_HOSTS_DIRS = (f'{HOME}/Library/Application Support/Chromium/NativeMessagingHosts',
+MAC_HOSTS_DIRS: Final[tuple[str, str, str, str]] = (f'{HOME}/Library/Application Support/Chromium/NativeMessagingHosts',
                   f'{HOME}/Library/Application Support/Google/Chrome Beta/NativeMessagingHosts',
                   f'{HOME}/Library/Application Support/Google/Chrome Canary/NativeMessagingHosts',
                   f'{HOME}/Library/Application Support/Google/Chrome/NativeMessagingHosts')
 
 MAC_BIN_PATH: Final[str] = '/opt/local/bin'
 
-SYSTEM_HOSTS_DIRS = ('/etc/chromium/native-messaging-hosts',
+SYSTEM_HOSTS_DIRS: Final[tuple[str, str, str]] = ('/etc/chromium/native-messaging-hosts',
                      '/etc/opt/chrome/native-messaging-hosts',
                      '/etc/opt/edge/native-messaging-hosts')
-USER_HOSTS_DIRS = (
+USER_HOSTS_DIRS: Final[tuple[str, str, str, str, str]] = (
     f'{xdg.BaseDirectory.xdg_config_home}/BraveSoftware/Brave-Browser/NativeMessagingHosts',
     f'{xdg.BaseDirectory.xdg_config_home}/chromium/NativeMessagingHosts',
     f'{xdg.BaseDirectory.xdg_config_home}/google-chrome-beta/NativeMessagingHosts',
     f'{xdg.BaseDirectory.xdg_config_home}/google-chrome-canary/NativeMessagingHosts',
     f'{xdg.BaseDirectory.xdg_config_home}/google-chrome/NativeMessagingHosts')
 
-COMMON_HOST_DATA: dict[str, str | None] = {
+COMMON_HOST_DATA: Final[dict[str, str | None]] = {
     'description': 'Opens a URL in mpv (for use with extension).',
     'path': None,
     'type': 'stdio'
 }
-HOST_DATA: dict[str, str | None | Sequence[str]] = {
+HOST_DATA: Final[dict[str, str | None | Sequence[str]]] = {
     **COMMON_HOST_DATA,
     # cspell:disable-next-line
     'allowed_origins': ['chrome-extension://ggijpepdpiehgbiknmfpfbhcalffjlbj/'],
     'name': 'sh.tat.open_in_mpv',
 }
-HOST_DATA_FIREFOX: dict[str, str | None | Sequence[str]] = {
+HOST_DATA_FIREFOX: Final[dict[str, str | None | Sequence[str]]] = {
     **COMMON_HOST_DATA,
     'allowed_extensions': ['{43e6f3ef-84a0-55f4-b9dd-d879106a24a9}'],
     'name': 'sh.tat.open-in-mpv',

--- a/open_in_mpv/constants.py
+++ b/open_in_mpv/constants.py
@@ -1,4 +1,4 @@
-from typing import Sequence
+from typing import Final, Sequence
 import os
 import platform
 
@@ -8,9 +8,9 @@ __all__ = ('HOST_DATA', 'HOST_DATA_FIREFOX', 'IS_LINUX', 'IS_MAC', 'IS_WIN', 'JS
            'MAC_HOSTS_DIRS', 'SYSTEM_HOSTS_DIRS', 'USER_CHROME_HOSTS_REG_PATH_WIN',
            'USER_HOSTS_DIRS')
 
-IS_MAC = bool(platform.mac_ver()[0])
-IS_WIN = bool(platform.win32_ver()[0])
-IS_LINUX = not IS_MAC and not IS_WIN
+IS_MAC: Final[bool] = bool(platform.mac_ver()[0])
+IS_WIN: Final[bool] = bool(platform.win32_ver()[0])
+IS_LINUX: Final[bool] = not IS_MAC and not IS_WIN
 
 JSON_FILENAME = 'sh.tat.open_in_mpv.json'
 HOME = os.environ.get('HOME', '')
@@ -21,6 +21,8 @@ MAC_HOSTS_DIRS = (f'{HOME}/Library/Application Support/Chromium/NativeMessagingH
                   f'{HOME}/Library/Application Support/Google/Chrome Beta/NativeMessagingHosts',
                   f'{HOME}/Library/Application Support/Google/Chrome Canary/NativeMessagingHosts',
                   f'{HOME}/Library/Application Support/Google/Chrome/NativeMessagingHosts')
+
+MAC_BIN_PATH: Final[str] = '/opt/local/bin'
 
 SYSTEM_HOSTS_DIRS = ('/etc/chromium/native-messaging-hosts',
                      '/etc/opt/chrome/native-messaging-hosts',

--- a/open_in_mpv/constants.py
+++ b/open_in_mpv/constants.py
@@ -26,8 +26,8 @@ MAC_HOSTS_DIRS: Final[tuple[str, ...]] = (
 MACPORTS_BIN_PATH: Final[str] = '/opt/local/bin'
 
 SYSTEM_HOSTS_DIRS: Final[tuple[str, str, str]] = ('/etc/chromium/native-messaging-hosts',
-                     '/etc/opt/chrome/native-messaging-hosts',
-                     '/etc/opt/edge/native-messaging-hosts')
+                                                  '/etc/opt/chrome/native-messaging-hosts',
+                                                  '/etc/opt/edge/native-messaging-hosts')
 USER_HOSTS_DIRS: Final[tuple[str, ...]] = (
     f'{xdg.BaseDirectory.xdg_config_home}/BraveSoftware/Brave-Browser/NativeMessagingHosts',
     f'{xdg.BaseDirectory.xdg_config_home}/chromium/NativeMessagingHosts',

--- a/open_in_mpv/open_in_mpv.py
+++ b/open_in_mpv/open_in_mpv.py
@@ -14,7 +14,7 @@ from loguru import logger
 import click
 import xdg.BaseDirectory
 
-from .constants import IS_MAC, IS_WIN
+from .constants import IS_MAC, IS_WIN, MAC_BIN_PATH
 
 FALLBACKS: Final[dict[str, Any]] = {
     'log': None,
@@ -52,11 +52,11 @@ VERSION = 'v0.1.7'
 
 def environment(data_resp: dict[str, Any], debugging: bool) -> dict[str, Any]:
     env: dict[str, Any] = os.environ.copy()
-    if isdir('/opt/local/bin'):
+    if isdir(MAC_BIN_PATH):
         logger.info('Detected MacPorts. Setting PATH.')
         data_resp['macports'] = True
         old_path = os.environ.get('PATH')
-        env['PATH'] = '/opt/local/bin' if not old_path else ':'.join('/opt/local/bin', old_path)
+        env['PATH'] = MAC_BIN_PATH if not old_path else ':'.join(MAC_BIN_PATH, old_path)
     if debugging:
         logger.debug('Environment:')
         for k, value in env.items():

--- a/open_in_mpv/open_in_mpv.py
+++ b/open_in_mpv/open_in_mpv.py
@@ -30,7 +30,7 @@ def get_log_path() -> str:
     try:
         return xdg.BaseDirectory.save_state_path('open-in-mpv')
     except KeyError:
-        FALLBACKS['log'] = tempfile.TemporaryDirectory(prefix='open-in-mpv')
+        FALLBACKS['log'] = tempfile.TemporaryDirectory(prefix='open-in-mpv') # pylint: disable=R1732
         return str(FALLBACKS['log'].name)
 
 @lru_cache()
@@ -56,7 +56,7 @@ def environment(data_resp: Dict[str, Any], debugging: bool) -> Dict[str, Any]:
         logger.info('Detected MacPorts. Setting PATH.')
         data_resp['macports'] = True
         old_path = os.environ.get('PATH')
-        env['PATH'] = '/opt/local/bin' if not old_path else ':'.join(('/opt/local/bin', old_path)) # pylint: disable=R1732
+        env['PATH'] = '/opt/local/bin' if not old_path else ':'.join(('/opt/local/bin', old_path))
 
     if debugging:
         logger.debug('Environment:')

--- a/open_in_mpv/open_in_mpv.py
+++ b/open_in_mpv/open_in_mpv.py
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: MIT
 from functools import lru_cache
-from os.path import dirname, exists, expanduser, expandvars, isdir, join as path_join
-from typing import Any, Final, BinaryIO, Callable, Mapping, TextIO, cast
+from os.path import dirname, exists, expandvars, expanduser, isdir, join as path_join
+from typing import Any, BinaryIO, Callable, Final, Mapping, TextIO, cast
 import json
 import os
 import socket

--- a/open_in_mpv/open_in_mpv.py
+++ b/open_in_mpv/open_in_mpv.py
@@ -26,7 +26,7 @@ def get_log_path() -> str:
     if IS_MAC:
         return expanduser('~/Library/Logs')
     if IS_WIN:
-        return expandvars(r'%LOCALDATA%\open-in-mpv')
+        return expandvars(r'%LOCALDATA%\open-in-mpv') # cspell:disable-line
     try:
         return xdg.BaseDirectory.save_state_path('open-in-mpv')
     except KeyError:

--- a/open_in_mpv/open_in_mpv.py
+++ b/open_in_mpv/open_in_mpv.py
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: MIT
 from functools import lru_cache
-from os.path import dirname, exists, expandvars, expanduser, isdir, join as path_join
+from os.path import dirname, exists, expanduser,  expandvars, isdir, join as path_join
 from typing import Any, BinaryIO, Callable, Final, Mapping, TextIO, cast
 import json
 import os

--- a/open_in_mpv/open_in_mpv.py
+++ b/open_in_mpv/open_in_mpv.py
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: MIT
 from functools import lru_cache
 from os.path import dirname, exists, expanduser, expandvars, isdir, join as path_join
-from typing import Any, Final, BinaryIO, Callable, cast, Mapping, TextIO
+from typing import Any, Final, BinaryIO, Callable, Mapping, TextIO, cast
 import json
 import os
 import socket

--- a/open_in_mpv/open_in_mpv.py
+++ b/open_in_mpv/open_in_mpv.py
@@ -1,5 +1,4 @@
 # SPDX-License-Identifier: MIT
-from .constants import IS_MAC, IS_WIN
 from functools import lru_cache
 from os.path import dirname, exists, expanduser, expandvars, isdir, join as path_join
 from typing import Any, Final, BinaryIO, Dict, Callable, Mapping, TextIO
@@ -14,6 +13,9 @@ import tempfile
 from loguru import logger
 import click
 import xdg.BaseDirectory
+
+from .constants import IS_MAC, IS_WIN
+
 
 fallbacks: Final[Dict[str, Any]] = {
     'log': None,
@@ -179,7 +181,7 @@ def real_main(log: TextIO) -> int:
         log.close()
         return 0
 
-    if (url := message.get('url', None) == None):
+    if (url := message.get('url', None) is None):
         logger.exception('No URL was given')
         print(json.dumps(dict(message='Missing URL!')))
         return 1

--- a/open_in_mpv/open_in_mpv.py
+++ b/open_in_mpv/open_in_mpv.py
@@ -85,6 +85,8 @@ def request(buffer: BinaryIO) -> Dict[str, Any]:
     return ret
 
 def cleanup() -> None:
+    global temp_dir, temp_file
+
     if temp_dir is not None:
         temp_dir.cleanup()
 

--- a/open_in_mpv/open_in_mpv.py
+++ b/open_in_mpv/open_in_mpv.py
@@ -22,7 +22,7 @@ def get_log_path() -> str:
     if IS_MAC:
         return expanduser('~/Library/Logs')
     if IS_WIN:
-        return expandvars(r"%LOCALDATA%\open-in-mpv")
+        return expandvars(r'%LOCALDATA%\open-in-mpv')
     try:
         return xdg.BaseDirectory.save_state_path('open-in-mpv')
     except KeyError:
@@ -35,7 +35,7 @@ def get_socket_path() -> str:
     if IS_MAC:
         return expanduser('~/Library/Caches/open-in-mpv.sock')
     if IS_WIN:
-         return expandvars(r"\\.\pipe\open-in-mpv")
+        return expandvars(r'\\.\pipe\open-in-mpv')
     try:
         return path_join(xdg.BaseDirectory.get_runtime_dir(), 'open-in-mpv.sock')
     except KeyError:
@@ -49,20 +49,19 @@ VERSION = 'v0.1.7'
 
 
 def environment(response: Dict[str, Any], debugging: bool) -> Dict[str, Any]:
-     env: Dict[str, Any] = os.environ.copy()
-     if isdir('/opt/local/bin'):
+    env: Dict[str, Any] = os.environ.copy()
+    if isdir('/opt/local/bin'):
         logger.info('Detected MacPorts. Setting PATH.')
         response['macports'] = True
         old_path = os.environ.get('PATH')
-        env['PATH'] = '/opt/local/bin' if not old_path else ':'.join(
-            ('/opt/local/bin', old_path))
+        env['PATH'] = '/opt/local/bin' if not old_path else ':'.join(('/opt/local/bin', old_path))
 
-     if debugging:
+    if debugging:
         logger.debug('Environment:')
         for k, value in env.items():
             logger.debug(f'  {k}={value}')
 
-     return env
+    return env
 
 def response(response: Dict[str, Any]) -> None:
     resp = json.dumps(response).encode()
@@ -201,9 +200,9 @@ def real_main(log: TextIO) -> int:
         spawn_init(url, log, data_resp['env'], is_debug)
     logger.debug('mpv should open soon')
     logger.debug('Exiting with status 0')
-    if (temp_log := fallbacks.get('log', None) != None):
+    if ((temp_log := fallbacks.get('log', None)) is not None):
         temp_log.cleanup()
-    if (temp_socket := fallbacks.get('socket', None) != None):
+    if ((temp_socket := fallbacks.get('socket', None)) is not None):
         temp_socket.close()
 
     return 0

--- a/open_in_mpv/open_in_mpv.py
+++ b/open_in_mpv/open_in_mpv.py
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: MIT
 from functools import lru_cache
-from os.path import dirname, exists, expanduser,  expandvars, isdir, join as path_join
+from os.path import dirname, exists, expanduser, expandvars, isdir, join as path_join
 from typing import Any, BinaryIO, Callable, Final, Mapping, TextIO, cast
 import json
 import os
@@ -16,10 +16,7 @@ import xdg.BaseDirectory
 
 from .constants import IS_MAC, IS_WIN, MACPORTS_BIN_PATH
 
-FALLBACKS: Final[dict[str, Any]] = {
-    'log': None,
-    'socket': None
-}
+FALLBACKS: Final[dict[str, Any]] = {'log': None, 'socket': None}
 
 
 @lru_cache()
@@ -27,11 +24,11 @@ def get_log_path() -> str:
     if IS_MAC:
         return expanduser('~/Library/Logs')
     if IS_WIN:
-        return expandvars(r'%LOCALDATA%\open-in-mpv') # cspell:disable-line
+        return expandvars(r'%LOCALDATA%\open-in-mpv')  # cspell:disable-line
     try:
         return xdg.BaseDirectory.save_state_path('open-in-mpv')
     except KeyError:
-        FALLBACKS['log'] = tempfile.TemporaryDirectory(prefix='open-in-mpv') # pylint: disable=R1732
+        FALLBACKS['log'] = tempfile.TemporaryDirectory(prefix='open-in-mpv')  # pylint: disable=R1732
         return str(FALLBACKS['log'].name)
 
 
@@ -44,8 +41,9 @@ def get_socket_path() -> str:
     try:
         return path_join(xdg.BaseDirectory.get_runtime_dir(), 'open-in-mpv.sock')
     except KeyError:
-        FALLBACKS['socket'] = tempfile.NamedTemporaryFile(prefix='open-in-mpv', suffix='.sock') # pylint: disable=R1732
+        FALLBACKS['socket'] = tempfile.NamedTemporaryFile(prefix='open-in-mpv', suffix='.sock')  # pylint: disable=R1732
         return str(FALLBACKS['socket'].name)
+
 
 LOG_PATH = get_log_path()
 MPV_SOCKET = get_socket_path()
@@ -147,6 +145,7 @@ def mpv_and_cleanup(url: str,
                       stdout=log)
         if not remove_socket():
             logger.error('Failed to remove socket file.')
+
     return callback
 
 
@@ -173,6 +172,7 @@ def get_callback(url: str,
             if not remove_socket():
                 logger.error('Failed to remove socket file')
             spawn_init(url, log, new_env, debug)
+
     return callback
 
 

--- a/open_in_mpv/open_in_mpv.py
+++ b/open_in_mpv/open_in_mpv.py
@@ -28,7 +28,7 @@ def get_log_path() -> str:
     except KeyError:
         global fallbacks
         fallbacks['log'] = tempfile.TemporaryDirectory(prefix='open-in-mpv')
-        return fallbacks['log'].name
+        return str(fallbacks['log'].name)
 
 @lru_cache()
 def get_socket_path() -> str:
@@ -41,7 +41,7 @@ def get_socket_path() -> str:
     except KeyError:
         global fallbacks
         fallbacks['socket'] = tempfile.NamedTemporaryFile(prefix='open-in-mpv', suffix='.sock')
-        return fallbacks['socket'].name
+        return str(fallbacks['socket'].name)
 
 LOG_PATH = get_log_path()
 MPV_SOCKET = get_socket_path()

--- a/open_in_mpv/open_in_mpv.py
+++ b/open_in_mpv/open_in_mpv.py
@@ -1,10 +1,10 @@
 # SPDX-License-Identifier: MIT
+from .constants import IS_MAC, IS_WIN
 from functools import lru_cache
-from os.path import dirname, exists, expanduser, isdir, join as path_join
-from typing import Any, Callable, Mapping, TextIO
+from os.path import dirname, exists, expanduser, expandvars, isdir, join as path_join
+from typing import Any, BinaryIO, Dict, Callable, Mapping, TextIO
 import json
 import os
-import platform
 import socket
 import struct
 import subprocess as sp
@@ -15,32 +15,81 @@ from loguru import logger
 import click
 import xdg.BaseDirectory
 
+# Globals used for the temporary directory fallback.
+temp_dir = None
+temp_file = None
 
 @lru_cache()
 def get_log_path() -> str:
-    if platform.mac_ver()[0]:
+    if IS_MAC:
         return expanduser('~/Library/Logs')
+    if IS_WIN:
+        return expandvars(r"%LOCALDATA%\open-in-mpv")
     try:
         return xdg.BaseDirectory.save_state_path('open-in-mpv')
     except KeyError:
-        with tempfile.TemporaryDirectory(prefix='open-in-mpv') as dir_:
-            return dir_
+        temp_dir = tempfile.TemporaryDirectory(prefix='open-in-mpv')
+        return temp_dir.name
 
 
 @lru_cache()
 def get_socket_path() -> str:
-    if platform.mac_ver()[0]:
+    if IS_MAC:
         return expanduser('~/Library/Caches/open-in-mpv.sock')
+    if IS_WIN:
+         return expandvars(r"\\.\pipe\open-in-mpv")
     try:
         return path_join(xdg.BaseDirectory.get_runtime_dir(), 'open-in-mpv.sock')
     except KeyError:
-        with tempfile.NamedTemporaryFile(prefix='open-in-mpv', suffix='.sock') as socket_fp:
-            return socket_fp.name
+        temp_file = tempfile.NamedTemporaryFile(prefix='open-in-mpv', suffix='.sock')
+        return temp_file.name
 
 
 LOG_PATH = get_log_path()
 MPV_SOCKET = get_socket_path()
-VERSION = 'v0.0.6'
+VERSION = 'v0.1.7'
+
+
+def environment(response: Dict[str, Any], debugging: bool) -> Dict[str, Any]:
+     env: Dict[str, Any] = os.environ.copy()
+     if isdir('/opt/local/bin'):
+        logger.info('Detected MacPorts. Setting PATH.')
+        response['macports'] = True
+        old_path = os.environ.get('PATH')
+        env['PATH'] = '/opt/local/bin' if not old_path else ':'.join(
+            ('/opt/local/bin', old_path))
+
+     if debugging:
+        logger.debug('Environment:')
+        for k, value in env.items():
+            logger.debug(f'  {k}={value}')
+
+     return env
+
+def response(response: Dict[str, Any]) -> None:
+    resp = json.dumps(response).encode()
+    size = struct.pack('@i', len(resp))
+    stdout_buffer: BinaryIO = sys.stdout.buffer
+    stdout_buffer.write(size)
+    stdout_buffer.write(resp)
+
+def request(buffer: BinaryIO) -> Dict[str, Any]:
+    ret: Dict[str, Any] = {}
+    req_len = struct.unpack('@i', buffer.read(4))[0]
+    message = json.loads(buffer.read(req_len).decode())
+    logger.debug('Message contents (%d): %s', req_len, message)
+    ret['init'] = 'init' in message
+    ret['url'] = message.get('url', None)
+    ret['debug'] = message.get('debug', False)
+    ret['single'] = message.get('single', True)
+    return ret
+
+def cleanup() -> None:
+    if temp_dir is not None:
+        temp_dir.cleanup()
+
+    if temp_file is not None:
+        temp_file.cleanup()
 
 
 def spawn(func: Callable[[], Any]) -> None:
@@ -133,53 +182,36 @@ def real_main(log: TextIO) -> int:
     message. Then the message is expected to be proceed.
     """
     os.makedirs(dirname(MPV_SOCKET), exist_ok=True)
-    stdin_buffer = sys.stdin.buffer
-    req_len = struct.unpack('@i', stdin_buffer.read(4))[0]
-    message = json.loads(stdin_buffer.read(req_len).decode())
-    logger.debug(f'Message contents ({req_len}): {message}')
-    if 'init' in message:
-        resp = json.dumps(dict(version=VERSION, logPath=log.name, socketPath=MPV_SOCKET)).encode()
-        size = struct.pack('@i', len(resp))
-        stdout_buffer = sys.stdout.buffer
-        stdout_buffer.write(size)
-        stdout_buffer.write(resp)
+    message: Dict[str, Any] = request(sys.stdin.buffer)
+
+    if message['init']:
+        response(dict(version=VERSION, logPath=log.name, socketPath=MPV_SOCKET))
         log.close()
         return 0
-    try:
-        url: str = message['url']
-    except KeyError:
+
+    if (url := message.get('url', None) == None):
         logger.exception('No URL was given')
         print(json.dumps(dict(message='Missing URL!')))
         return 1
+
     if (is_debug := message.get('debug', False)):
         logger.info('Debug mode enabled.')
+
     single: bool = message.get('single', True)
+
     # MacPorts
-    new_env = os.environ.copy()
-    data_resp: dict[str, Any] = dict(version=VERSION, log_path=log.name, message='About to spawn')
-    if isdir('/opt/local/bin'):
-        logger.info('Detected MacPorts. Setting PATH.')
-        data_resp['macports'] = True
-        old_path = os.environ.get('PATH')
-        new_env['PATH'] = '/opt/local/bin' if not old_path else ':'.join(
-            ('/opt/local/bin', old_path))
-    data_resp['env'] = new_env
-    if is_debug:
-        logger.debug('Environment:')
-        for k, value in new_env.items():
-            logger.debug(f'  {k}={value}')
+    data_resp: Dict[str, Any] = dict(version=VERSION, log_path=log.name, message='About to spawn')
+    data_resp['env'] = environment(data_resp, is_debug)
     logger.debug('About to spawn')
-    resp = json.dumps(data_resp).encode()
-    size = struct.pack('@i', len(resp))
-    stdout_buffer = sys.stdout.buffer
-    stdout_buffer.write(size)
-    stdout_buffer.write(resp)
+    response(data_resp)
+
     if exists(MPV_SOCKET) and single:
-        spawn(get_callback(url, log, new_env, is_debug))
+        spawn(get_callback(url, log, data_resp['env'], is_debug))
     else:
-        spawn_init(url, log, new_env, is_debug)
+        spawn_init(url, log, data_resp['env'], is_debug)
     logger.debug('mpv should open soon')
     logger.debug('Exiting with status 0')
+    cleanup()
     return 0
 
 

--- a/open_in_mpv/open_in_mpv.py
+++ b/open_in_mpv/open_in_mpv.py
@@ -16,8 +16,7 @@ import xdg.BaseDirectory
 
 from .constants import IS_MAC, IS_WIN
 
-
-fallbacks: Final[Dict[str, Any]] = {
+FALLBACKS: Final[Dict[str, Any]] = {
     'log': None,
     'socket': None
 }
@@ -31,8 +30,8 @@ def get_log_path() -> str:
     try:
         return xdg.BaseDirectory.save_state_path('open-in-mpv')
     except KeyError:
-        fallbacks['log'] = tempfile.TemporaryDirectory(prefix='open-in-mpv')
-        return str(fallbacks['log'].name)
+        FALLBACKS['log'] = tempfile.TemporaryDirectory(prefix='open-in-mpv')
+        return str(FALLBACKS['log'].name)
 
 @lru_cache()
 def get_socket_path() -> str:
@@ -43,8 +42,8 @@ def get_socket_path() -> str:
     try:
         return path_join(xdg.BaseDirectory.get_runtime_dir(), 'open-in-mpv.sock')
     except KeyError:
-        fallbacks['socket'] = tempfile.NamedTemporaryFile(prefix='open-in-mpv', suffix='.sock')
-        return str(fallbacks['socket'].name)
+        FALLBACKS['socket'] = tempfile.NamedTemporaryFile(prefix='open-in-mpv', suffix='.sock') # pylint: disable=R1732
+        return str(FALLBACKS['socket'].name)
 
 LOG_PATH = get_log_path()
 MPV_SOCKET = get_socket_path()
@@ -57,7 +56,7 @@ def environment(data_resp: Dict[str, Any], debugging: bool) -> Dict[str, Any]:
         logger.info('Detected MacPorts. Setting PATH.')
         data_resp['macports'] = True
         old_path = os.environ.get('PATH')
-        env['PATH'] = '/opt/local/bin' if not old_path else ':'.join(('/opt/local/bin', old_path))
+        env['PATH'] = '/opt/local/bin' if not old_path else ':'.join(('/opt/local/bin', old_path)) # pylint: disable=R1732
 
     if debugging:
         logger.debug('Environment:')
@@ -181,7 +180,7 @@ def real_main(log: TextIO) -> int:
         log.close()
         return 0
 
-    if ((url := message.get('url', None)) is None):
+    if ((url := message.get('url', None)) is None): # pylint: disable=C0325
         logger.exception('No URL was given')
         print(json.dumps(dict(message='Missing URL!')))
         return 1

--- a/open_in_mpv/open_in_mpv.py
+++ b/open_in_mpv/open_in_mpv.py
@@ -142,7 +142,8 @@ def mpv_and_cleanup(url: str,
                       env=new_env,
                       stderr=log,
                       stdout=log)
-        remove_socket()
+        if not remove_socket():
+            logger.error('Failed to remove socket file.')
 
     return callback
 
@@ -167,7 +168,8 @@ def get_callback(url: str,
             sock.send(json.dumps(dict(command=['loadfile', url])).encode(errors='strict') + b'\n')
         except socket.error:
             logger.exception('Connection refused')
-            remove_socket()
+            if not remove_socket():
+                logger.error('Failed to remove socket file')
             spawn_init(url, log, new_env, debug)
 
     return callback
@@ -212,8 +214,6 @@ def real_main(log: TextIO) -> int:
     logger.debug('Exiting with status 0')
     if FALLBACKS['log']:
         FALLBACKS['log'].cleanup()
-    if FALLBACKS['socket']:
-        FALLBACKS['socket'].close()
     return 0
 
 

--- a/open_in_mpv/open_in_mpv.py
+++ b/open_in_mpv/open_in_mpv.py
@@ -181,7 +181,7 @@ def real_main(log: TextIO) -> int:
         log.close()
         return 0
 
-    if (url := message.get('url', None) is None):
+    if ((url := message.get('url', None)) is None):
         logger.exception('No URL was given')
         print(json.dumps(dict(message='Missing URL!')))
         return 1

--- a/open_in_mpv/open_in_mpv.py
+++ b/open_in_mpv/open_in_mpv.py
@@ -63,7 +63,6 @@ def environment(data_resp: dict[str, Any], debugging: bool) -> dict[str, Any]:
         logger.debug('Environment:')
         for k, value in env.items():
             logger.debug(f'  {k}={value}')
-
     return env
 
 
@@ -95,7 +94,6 @@ def remove_socket() -> bool:
         os.remove(MPV_SOCKET)
     except OSError:
         return False
-
     return True
 
 
@@ -149,7 +147,6 @@ def mpv_and_cleanup(url: str,
                       stdout=log)
         if not remove_socket():
             logger.error('Failed to remove socket file.')
-
     return callback
 
 
@@ -176,7 +173,6 @@ def get_callback(url: str,
             if not remove_socket():
                 logger.error('Failed to remove socket file')
             spawn_init(url, log, new_env, debug)
-
     return callback
 
 

--- a/open_in_mpv/open_in_mpv.py
+++ b/open_in_mpv/open_in_mpv.py
@@ -202,10 +202,10 @@ def real_main(log: TextIO) -> int:
         spawn_init(url, log, data_resp['env'], is_debug)
     logger.debug('mpv should open soon')
     logger.debug('Exiting with status 0')
-    if fallbacks['log'] is not None:
-        fallbacks['log'].cleanup()
-    if fallbacks['socket'] is not None:
-        fallbacks['socket'].close()
+    if FALLBACKS['log'] is not None:
+        FALLBACKS['log'].cleanup()
+    if FALLBACKS['socket'] is not None:
+        FALLBACKS['socket'].close()
     return 0
 
 


### PR DESCRIPTION
These changes are from the old revision of open-in-mpv that includes win32 support. I figured it would be wise to get these changes in first before implementing and testing on Windows 11.

The tempfile oversight is caused by using the context variant of it; upon exiting the context the contents and directory are deleted so the only solution is global variables. If you can think of a better method im up to hearing it.